### PR TITLE
Changed Otp display from button to display

### DIFF
--- a/server/utils/emailTemplates/otpTemplate.js
+++ b/server/utils/emailTemplates/otpTemplate.js
@@ -155,7 +155,7 @@ export const otpTemplate = (name, otp) => `
                       margin-bottom: 20px;
                       text-align: center;
                     ">
-                        <a href="#"
+                        <div href="#"
                           style="
                         line-height: 24px;
                         border-radius: 0px;
@@ -166,7 +166,7 @@ export const otpTemplate = (name, otp) => `
                         border: 1px solid rgb(173, 54, 93);
                         text-decoration-line: none;
                         color: rgb(173, 54, 93);
-                      " target="_blank"><span class="il">${otp}</span></a>
+                      " target="_blank"><span class="il">${otp}</span></div>
                       </div>
                     </div> 
                       <p>OTP expires after 1 hour.</p>


### PR DESCRIPTION
With respect to issue#54.
Replaced the anchor tag enclosing the OTP with a div tag, thereby enabling the user to copy the OTP with ease.
![Screenshot 2022-10-04 184227](https://user-images.githubusercontent.com/96298187/193828152-6435e1c6-bab8-420a-9518-c4b6165d0162.png)
